### PR TITLE
Fixed bug where Ldap::Array didnt take :accessor, :reader or :writer property into account.

### DIFF
--- a/lib/ldap/array.rb
+++ b/lib/ldap/array.rb
@@ -74,32 +74,45 @@ module Ldap
                end
     end
 
-    def initialize(*args)
+    def initialize(model, name, options = {})
       super
-      model.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-        def #{name.to_s}=(v)
-          case v
-          when Ldap::Array
-            v.setup(self, properties[:#{name}])
-          else
-            vv = Ldap::Array.new(self, properties[:#{name}])
-            vv.replace(v || [])
-            v = vv
-          end
-          attribute_set(:#{name}, v)
-        end
 
-        def #{name.to_s}
-          v = attribute_get(:#{name})
-          case v
-          when Ldap::Array
-            v.setup(self, properties[:#{name}])
-          else
-            vv = Ldap::Array.new(self, properties[:#{name}])
-            vv.replace(v || [])
+      no_writer = options[:writer] == :private || options[:accessor] == :private
+      no_reader = options[:reader] == :private || options[:accessor] == :private    
+
+      unless no_writer
+        #Creates instance method for writer
+        model.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+          def #{name.to_s}=(v)
+            case v
+            when Ldap::Array
+              v.setup(self, properties[:#{name}])
+            else
+              vv = Ldap::Array.new(self, properties[:#{name}])
+              vv.replace(v || [])
+              v = vv
+            end
+            attribute_set(:#{name}, v)
           end
-        end
-      RUBY
-    end
-  end
+        RUBY
+      end #unless no_writer
+
+      unless no_reader
+        #Creates instance method for reader
+        model.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+          def #{name.to_s}
+            v = attribute_get(:#{name})
+            case v
+            when Ldap::Array
+              v.setup(self, properties[:#{name}])
+            else
+              vv = Ldap::Array.new(self, properties[:#{name}])
+              vv.replace(v || [])
+            end
+          end
+        RUBY
+      end #unless no_writer
+
+    end # def initialize
+  end # class LdapArray
 end

--- a/spec/ldap_array_spec.rb
+++ b/spec/ldap_array_spec.rb
@@ -5,12 +5,12 @@ require 'dm-migrations'
 require 'dm-sqlite-adapter'
 
 class A
-  
   include DataMapper::Resource
-
-  property :id, Serial
-
-  property :list, ::Ldap::LdapArray
+  property :id,           Serial
+  property :list,         ::Ldap::LdapArray,    :accessor => :public
+  property :hidden_list,  ::Ldap::LdapArray,    :accessor => :private
+  property :write_list,   ::Ldap::LdapArray,    :reader => :private, :writer => :public
+  property :read_list,    ::Ldap::LdapArray,    :reader => :public, :writer => :private
 end
 
 require 'fileutils'
@@ -72,4 +72,49 @@ describe Ldap::LdapArray do
     resource.list.should == ["2"]
     resource.list.class.should == Ldap::Array
   end
+  
+  context 'when :accessor property is set to :private' do 
+    it 'should not create a write accessor' do
+      @resource.should_not respond_to(:hidden_list=)
+    end
+
+    it 'should not create a reade accessor' do
+      @resource.should_not respond_to(:hidden_list)
+    end  
+  end
+
+  context 'when :accessor property is set to :public' do 
+    it 'should create a write accessor' do
+      @resource.should respond_to(:list=)
+    end
+
+    it 'should create a reade accessor' do
+      @resource.should respond_to(:list)
+    end  
+  end
+  
+  context 'when :writer property is set to :public' do
+    it 'should create a write accessor' do
+      @resource.should respond_to(:write_list=)
+    end
+  end
+
+  context 'when :writer property is set to :private' do
+    it 'should not create a write accessor' do
+      @resource.should_not respond_to(:read_list=)
+    end
+  end
+
+  context 'when :reader property is set to :public' do
+    it 'should create a read accessor' do
+      @resource.should respond_to(:read_list)
+    end
+  end
+
+  context 'when :reader property is set to :private' do
+    it 'should not create a read accessor' do
+      @resource.should_not respond_to(:write_list)
+    end
+  end
+  
 end


### PR DESCRIPTION
Attributes defined as Ldap::Array always produced attributes on the model, no matter what access controllers used in the model.
